### PR TITLE
`PyscfCalculation`: Add timing information

### DIFF
--- a/src/aiida_pyscf/calculations/templates/mean_field.py.j2
+++ b/src/aiida_pyscf/calculations/templates/mean_field.py.j2
@@ -4,7 +4,9 @@ mean_field = dft.{{ method | default('UKS') }}(structure)
 mean_field.xc = '{{ xc | default('pbe') }}'
 {% if grids is defined %}mean_field.grids.level = {{ grids['level'] | default(3) }}{% endif %}
 
+time_mean_field_start = time.perf_counter()
 mean_field_run = mean_field.run()
 
+results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
 results['total_energy'] = mean_field_run.e_tot
 results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()

--- a/src/aiida_pyscf/calculations/templates/optimizer.py.j2
+++ b/src/aiida_pyscf/calculations/templates/optimizer.py.j2
@@ -4,6 +4,11 @@ convergence_parameters = {}
 convergence_parameters['{{ key }}'] = {{ value }}
 {% endfor %}
 {% endif %}
+
+time_optimizer_start = time.perf_counter()
+
 optimizer = mean_field.Gradients().optimizer(solver='{{ solver }}')
 optimized = optimizer.kernel(convergence_parameters)
+
+results['timings']['optimizer'] = time.perf_counter() - time_optimizer_start
 results['optimized_coordinates'] = optimized.atom_coords().tolist()

--- a/src/aiida_pyscf/calculations/templates/results.py.j2
+++ b/src/aiida_pyscf/calculations/templates/results.py.j2
@@ -1,4 +1,4 @@
-import json
+results['timings']['total'] = time.perf_counter() - time_start
 
 with open('{{ results.filename_output }}', 'w') as handle:
     json.dump(results, handle)

--- a/src/aiida_pyscf/calculations/templates/script.py.j2
+++ b/src/aiida_pyscf/calculations/templates/script.py.j2
@@ -1,5 +1,13 @@
+import json
+import time
+
 {% if preamble %}{{ preamble }}{% endif %}
-results = {}
+
+results = {
+    'timings': {}
+}
+
+time_start = time.perf_counter()
 
 {{ script_structure }}
 {{ script_mean_field }}

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -1,5 +1,13 @@
+import json
+import time
 
-results = {}
+
+
+results = {
+    'timings': {}
+}
+
+time_start = time.perf_counter()
 
 from pyscf import gto
 structure = gto.Mole()
@@ -20,12 +28,14 @@ mean_field = dft.UKS(structure)
 mean_field.xc = 'pbe'
 
 
+time_mean_field_start = time.perf_counter()
 mean_field_run = mean_field.run()
 
+results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
 results['total_energy'] = mean_field_run.e_tot
 results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
-import json
+results['timings']['total'] = time.perf_counter() - time_start
 
 with open('results.json', 'w') as handle:
     json.dump(results, handle)

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -1,5 +1,13 @@
+import json
+import time
 
-results = {}
+
+
+results = {
+    'timings': {}
+}
+
+time_start = time.perf_counter()
 
 from pyscf import gto
 structure = gto.Mole()
@@ -20,8 +28,10 @@ mean_field = dft.UKS(structure)
 mean_field.xc = 'pbe'
 
 
+time_mean_field_start = time.perf_counter()
 mean_field_run = mean_field.run()
 
+results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
 results['total_energy'] = mean_field_run.e_tot
 results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 convergence_parameters = {}
@@ -30,10 +40,15 @@ convergence_parameters = {}
 convergence_parameters['convergence_energy'] = 2.0
 
 
+
+time_optimizer_start = time.perf_counter()
+
 optimizer = mean_field.Gradients().optimizer(solver='geomeTRIC')
 optimized = optimizer.kernel(convergence_parameters)
+
+results['timings']['optimizer'] = time.perf_counter() - time_optimizer_start
 results['optimized_coordinates'] = optimized.atom_coords().tolist()
-import json
+results['timings']['total'] = time.perf_counter() - time_start
 
 with open('results.json', 'w') as handle:
     json.dump(results, handle)


### PR DESCRIPTION
The script generated by the plugin is updated to add the `timings` dictionary to the `results` output. The following timings are added:

* `mean_field`
* `optimizer`
* `total`

The `optimizer` key will only be present if the optimization was enabled through the input parameters of course.