### PR TITLE
Devops: add GitHub Actions workflow for continuous deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,107 @@
+name: cd
+
+on:
+    push:
+        tags:
+        -   'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+
+    validate-release-tag:
+
+        if: github.repository == 'microsoft/aiida-pyscf'
+        runs-on: ubuntu-latest
+
+        steps:
+        -   name: Checkout source
+            uses: actions/checkout@v2
+
+        -   name: Set up Python 3.10
+            uses: actions/setup-python@v4
+            with:
+                python-version: '3.10'
+
+        -   name: Validate the tag version against the package version
+            run: python .github/workflows/validate_release_tag.py $GITHUB_REF
+
+    pre-commit:
+
+        needs: [validate-release-tag]
+        runs-on: ubuntu-latest
+
+        steps:
+        -   uses: actions/checkout@v2
+
+        -   name: Install Python
+            uses: actions/setup-python@v4
+            with:
+                python-version: '3.10'
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
+
+        -   name: Install Python package and dependencies
+            run: pip install -e .[pre-commit,tests]
+
+        -   name: Run pre-commit
+            run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+
+    tests:
+
+        needs: [validate-release-tag]
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
+
+        strategy:
+            matrix:
+                python-version: ['3.8', '3.9', '3.10', '3.11']
+
+        services:
+            rabbitmq:
+                image: rabbitmq:latest
+                ports:
+                -   5672:5672
+
+        steps:
+        -   uses: actions/checkout@v2
+
+        -   name: Install Python ${{ matrix.python-version }}
+            uses: actions/setup-python@v4
+            with:
+                python-version: ${{ matrix.python-version }}
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
+
+        -   name: Install system dependencies
+            run: sudo apt update && sudo apt install postgresql
+
+        -   name: Install Python package and dependencies
+            run: pip install -e .[tests]
+
+        -   name: Run pytest
+            env:
+                AIIDA_WARN_v3: true
+            run: pytest -sv tests
+
+    publish:
+
+        name: Publish to PyPI
+        needs: [pre-commit, tests]
+        runs-on: ubuntu-latest
+
+        steps:
+        -   name: Checkout source
+            uses: actions/checkout@v2
+
+        -   name: Set up Python 3.10
+            uses: actions/setup-python@v4
+            with:
+                python-version: '3.10'
+
+        -   name: Install flit
+            run: pip install flit~=3.4
+
+        -   name: Build and publish
+            run: flit publish
+            env:
+                FLIT_USERNAME: __token__
+                FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Validate that the version in the tag label matches the version of the package."""
+import argparse
+import ast
+from pathlib import Path
+
+
+def get_version_from_module(content: str) -> str:
+    """Get the ``__version__`` attribute from a module.
+
+    .. note:: This has been adapted from :mod:`setuptools.config`.
+    """
+    try:
+        module = ast.parse(content)
+    except SyntaxError as exception:
+        raise IOError('Unable to parse module.') from exception
+
+    try:
+        return next(
+            ast.literal_eval(statement.value) for statement in module.body if isinstance(statement, ast.Assign)
+            for target in statement.targets if isinstance(target, ast.Name) and target.id == '__version__'
+        )
+    except StopIteration as exception:
+        raise IOError('Unable to find the `__version__` attribute in the module.') from exception
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('GITHUB_REF', help='The GITHUB_REF environmental variable')
+    args = parser.parse_args()
+    TAG_PREFIX = 'refs/tags/v'
+    assert args.GITHUB_REF.startswith(TAG_PREFIX), f'GITHUB_REF should start with "{TAG_PREFIX}": {args.GITHUB_REF}'
+    tag_version = args.GITHUB_REF.removeprefix(TAG_PREFIX)
+    package_version = get_version_from_module(Path('src/aiida_pyscf/__init__.py').read_text(encoding='utf-8'))
+    error_message = f'The tag version `{tag_version}` is different from the package version `{package_version}`'
+    assert tag_version == package_version, error_message


### PR DESCRIPTION
This workflow will be triggered when a new tag is pushed that matches a semantic versioning pattern. If it is pushed to the main repository of the `microsoft` account, a Python script `validate_release_tag.py` is run that will parse the `__version__` attribute of the package and compare it to the version of the tag. If they don't match, the workflow is aborted.

Otherwise, the pre-commit and the unit test suite is ran, and when successfull, `flit` is used to build and publish the package to PyPI.