### PR TITLE
`PyscfCalculation`: Use `PrefixLoader` for template environment loader

### DIFF
--- a/src/aiida_pyscf/calculations/base.py
+++ b/src/aiida_pyscf/calculations/base.py
@@ -10,7 +10,7 @@ from aiida.common.folders import Folder
 from aiida.engine import CalcJob, CalcJobProcessSpec
 from aiida.orm import Dict, StructureData
 from ase.io.xyz import write_xyz
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, PackageLoader, PrefixLoader
 
 __all__ = ('PyscfCalculation',)
 
@@ -104,10 +104,10 @@ class PyscfCalculation(CalcJob):
 
         :returns: The input script template rendered with the parameters provided by ``get_parameters``.
         """
-        environment = Environment(loader=PackageLoader('aiida_pyscf.calculations.base'),)
+        environment = Environment(loader=PrefixLoader({'pyscf': PackageLoader('aiida_pyscf.calculations.base')}))
         parameters = self.get_parameters()
 
-        return environment.get_template('script.py.j2').render(
+        return environment.get_template('pyscf/script.py.j2').render(
             structure=parameters.get('structure', {}),
             mean_field=parameters.get('mean_field', {}),
             optimizer=parameters.get('optimizer', None),

--- a/src/aiida_pyscf/calculations/templates/script.py.j2
+++ b/src/aiida_pyscf/calculations/templates/script.py.j2
@@ -13,12 +13,12 @@ def main():
     time_start = time.perf_counter()
 
 {% filter indent(width=4) %}
-{% include 'structure.py.j2' %}
-{% include 'mean_field.py.j2' %}
+{% include 'pyscf/structure.py.j2' %}
+{% include 'pyscf/mean_field.py.j2' %}
 {% if optimizer %}
-{% include 'optimizer.py.j2' %}
+{% include 'pyscf/optimizer.py.j2' %}
 {% endif %}
-{% include 'results.py.j2' %}
+{% include 'pyscf/results.py.j2' %}
 {% endfilter %}
 
 


### PR DESCRIPTION
By using the `PrefixLoader`, it is possible for subclasses to replace specific templates while keeping the defaults from `PyscfCalculation`. The subclass simply needs to add their own `PrefixLoader` when overriding the `render_script` method.