### PR TITLE
`PyscfCalculation`: Improve white-space in rendered script

### DIFF
--- a/src/aiida_pyscf/calculations/base.py
+++ b/src/aiida_pyscf/calculations/base.py
@@ -105,6 +105,9 @@ class PyscfCalculation(CalcJob):
         :returns: The input script template rendered with the parameters provided by ``get_parameters``.
         """
         environment = Environment(loader=PrefixLoader({'pyscf': PackageLoader('aiida_pyscf.calculations.base')}))
+        environment.trim_blocks = True
+        environment.lstrip_blocks = True
+        environment.keep_trailing_newline = True
         parameters = self.get_parameters()
 
         return environment.get_template('pyscf/script.py.j2').render(

--- a/src/aiida_pyscf/calculations/templates/mean_field.py.j2
+++ b/src/aiida_pyscf/calculations/templates/mean_field.py.j2
@@ -1,12 +1,14 @@
+# Section: Mean field
 from pyscf import scf
-
 mean_field = scf.{{ mean_field.method | default('UKS') }}(structure)
-{% if mean_field %}{% for key, value in mean_field.items() %}mean_field.{{ key }} = {{ value|tojson }}
-{% endfor %}{% endif %}
-
-time_mean_field_start = time.perf_counter()
+{% if mean_field %}
+    {% for key, value in mean_field.items() %}
+mean_field.{{ key }} = {{ value|tojson }}
+    {% endfor %}
+{% endif %}
+mean_field_start = time.perf_counter()
 mean_field_run = mean_field.run()
 
-results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
+results['timings']['mean_field'] = time.perf_counter() - mean_field_start
 results['total_energy'] = mean_field_run.e_tot
 results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()

--- a/src/aiida_pyscf/calculations/templates/optimizer.py.j2
+++ b/src/aiida_pyscf/calculations/templates/optimizer.py.j2
@@ -1,14 +1,14 @@
+# Section: Optimizer
 convergence_parameters = {}
 {% if optimizer.convergence_parameters %}
-{% for key, value in optimizer.convergence_parameters.items() %}
+    {% for key, value in optimizer.convergence_parameters.items() %}
 convergence_parameters['{{ key }}'] = {{ value }}
-{% endfor %}
+    {% endfor %}
 {% endif %}
 
-time_optimizer_start = time.perf_counter()
-
+optimizer_start = time.perf_counter()
 optimizer = mean_field.Gradients().optimizer(solver='{{ optimizer.solver }}')
-optimized = optimizer.kernel(convergence_parameters)
+optimizer_run = optimizer.kernel(convergence_parameters)
 
-results['timings']['optimizer'] = time.perf_counter() - time_optimizer_start
-results['optimized_coordinates'] = optimized.atom_coords().tolist()
+results['timings']['optimizer'] = time.perf_counter() - optimizer_start
+results['optimized_coordinates'] = optimizer_run.atom_coords().tolist()

--- a/src/aiida_pyscf/calculations/templates/results.py.j2
+++ b/src/aiida_pyscf/calculations/templates/results.py.j2
@@ -1,3 +1,4 @@
+# Section: Results
 results['timings']['total'] = time.perf_counter() - time_start
 
 with open('{{ results.filename_output }}', 'w') as handle:

--- a/src/aiida_pyscf/calculations/templates/script.py.j2
+++ b/src/aiida_pyscf/calculations/templates/script.py.j2
@@ -12,14 +12,17 @@ def main():
 
     time_start = time.perf_counter()
 
-{% filter indent(width=4) %}
-{% include 'pyscf/structure.py.j2' %}
-{% include 'pyscf/mean_field.py.j2' %}
-{% if optimizer %}
-{% include 'pyscf/optimizer.py.j2' %}
-{% endif %}
-{% include 'pyscf/results.py.j2' %}
-{% endfilter %}
+    {% filter indent(width=4) +%}
+    {% include 'pyscf/structure.py.j2' %}
+
+    {% include 'pyscf/mean_field.py.j2' %}
+
+    {% if optimizer %}
+    {% include 'pyscf/optimizer.py.j2' %}
+    {% endif %}
+
+    {% include 'pyscf/results.py.j2' %}
+    {% endfilter %}
 
 
 if __name__ == '__main__':

--- a/src/aiida_pyscf/calculations/templates/structure.py.j2
+++ b/src/aiida_pyscf/calculations/templates/structure.py.j2
@@ -1,9 +1,15 @@
+# Section: Structure definition
 from pyscf import gto
 structure = gto.Mole()
-{% if structure %}{% for key, value in structure.items() %}{% if key != 'xyz' %}structure.{{ key }} = {{ value }}
-{% endif %}{% endfor %}{% endif %}
+{% if structure %}
+    {% for key, value in structure.items() %}
+        {% if key != 'xyz' %}
+structure.{{ key }} = {{ value }}
+        {% endif %}
+    {% endfor %}
+{% endif %}
 structure.unit = 'Ang'
 structure.atom = """
-{{ structure.xyz }}
+{{ structure.xyz|trim }}
 """
 structure.build()

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -13,34 +13,33 @@ def main():
     time_start = time.perf_counter()
 
 
+    # Section: Structure definition
     from pyscf import gto
     structure = gto.Mole()
-
     structure.unit = 'Ang'
     structure.atom = """
     O       0.000000000000000      0.000000000000000      0.119262000000000
     H       0.000000000000000      0.763239000000000     -0.477047000000000
     H       0.000000000000000     -0.763239000000000     -0.477047000000000
-
     """
     structure.build()
+
+    # Section: Mean field
     from pyscf import scf
-
     mean_field = scf.UKS(structure)
-
-
-    time_mean_field_start = time.perf_counter()
+    mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run()
 
-    results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
+    results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
+
+    # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 
     with open('results.json', 'w') as handle:
         json.dump(results, handle)
-
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_mean_field.pyr
+++ b/tests/calculations/test_base/test_parameters_mean_field.pyr
@@ -13,38 +13,37 @@ def main():
     time_start = time.perf_counter()
 
 
+    # Section: Structure definition
     from pyscf import gto
     structure = gto.Mole()
-
     structure.unit = 'Ang'
     structure.atom = """
     O       0.000000000000000      0.000000000000000      0.119262000000000
     H       0.000000000000000      0.763239000000000     -0.477047000000000
     H       0.000000000000000     -0.763239000000000     -0.477047000000000
-
     """
     structure.build()
-    from pyscf import scf
 
+    # Section: Mean field
+    from pyscf import scf
     mean_field = scf.RHF(structure)
     mean_field.xc = "PBE"
     mean_field.grids = {"level": 3}
     mean_field.method = "RHF"
     mean_field.diis_start_cycle = 2
-
-
-    time_mean_field_start = time.perf_counter()
+    mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run()
 
-    results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
+    results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
+
+    # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 
     with open('results.json', 'w') as handle:
         json.dump(results, handle)
-
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -13,49 +13,43 @@ def main():
     time_start = time.perf_counter()
 
 
+    # Section: Structure definition
     from pyscf import gto
     structure = gto.Mole()
-
     structure.unit = 'Ang'
     structure.atom = """
     O       0.000000000000000      0.000000000000000      0.119262000000000
     H       0.000000000000000      0.763239000000000     -0.477047000000000
     H       0.000000000000000     -0.763239000000000     -0.477047000000000
-
     """
     structure.build()
+
+    # Section: Mean field
     from pyscf import scf
-
     mean_field = scf.UKS(structure)
-
-
-    time_mean_field_start = time.perf_counter()
+    mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run()
 
-    results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
+    results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
+    # Section: Optimizer
     convergence_parameters = {}
-
-
     convergence_parameters['convergence_energy'] = 2.0
 
-
-
-    time_optimizer_start = time.perf_counter()
-
+    optimizer_start = time.perf_counter()
     optimizer = mean_field.Gradients().optimizer(solver='geomeTRIC')
-    optimized = optimizer.kernel(convergence_parameters)
+    optimizer_run = optimizer.kernel(convergence_parameters)
 
-    results['timings']['optimizer'] = time.perf_counter() - time_optimizer_start
-    results['optimized_coordinates'] = optimized.atom_coords().tolist()
+    results['timings']['optimizer'] = time.perf_counter() - optimizer_start
+    results['optimized_coordinates'] = optimizer_run.atom_coords().tolist()
 
+    # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 
     with open('results.json', 'w') as handle:
         json.dump(results, handle)
-
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_structure.pyr
+++ b/tests/calculations/test_base/test_parameters_structure.pyr
@@ -13,37 +13,36 @@ def main():
     time_start = time.perf_counter()
 
 
+    # Section: Structure definition
     from pyscf import gto
     structure = gto.Mole()
     structure.cart = True
     structure.spin = 2
     structure.charge = 1
-
     structure.unit = 'Ang'
     structure.atom = """
     O       0.000000000000000      0.000000000000000      0.119262000000000
     H       0.000000000000000      0.763239000000000     -0.477047000000000
     H       0.000000000000000     -0.763239000000000     -0.477047000000000
-
     """
     structure.build()
+
+    # Section: Mean field
     from pyscf import scf
-
     mean_field = scf.UKS(structure)
-
-
-    time_mean_field_start = time.perf_counter()
+    mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run()
 
-    results['timings']['mean_field'] = time.perf_counter() - time_mean_field_start
+    results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
+
+    # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 
     with open('results.json', 'w') as handle:
         json.dump(results, handle)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `render_script` method is updated to set a number of configuration parameters on the rendering environment that control whitespace:

* `environment.trim_blocks = True`
* `environment.lstrip_blocks = True`
* `environment.keep_trailing_newline = True`

These flags ensure that whitespace introduced by control structures such as `{% %}` statements are ignored. This in turn allows to properly indent the logic statements in the templates, which increases readability, without it leading to unnecessary indentation and whitespace in the rendered template.