### PR TITLE
`PyscfCalculation`: Add validation for `optimizer` parameters

### DIFF
--- a/src/aiida_pyscf/calculations/base.py
+++ b/src/aiida_pyscf/calculations/base.py
@@ -81,6 +81,16 @@ class PyscfCalculation(CalcJob):
             options = ' '.join(valid_methods)
             return f'specified mean field method {mean_field_method} is not supported, choose from: {options}'
 
+        if 'optimizer' in parameters:
+            valid_solvers = ('geometric', 'berny')
+            solver = parameters['optimizer'].get('solver')
+
+            if solver is None:
+                return f'No solver specified in `optimizer` parameters. Choose from: {valid_solvers}'
+
+            if solver.lower() not in valid_solvers:
+                return f'Invalid solver `{solver}` specified in `optimizer` parameters. Choose from: {valid_solvers}'
+
     def get_parameters(self) -> dict[str, t.Any]:
         """Return the parameters to use for renderning the input script.
 

--- a/tests/calculations/test_base.py
+++ b/tests/calculations/test_base.py
@@ -103,3 +103,16 @@ def test_invalid_parameters_mean_field_method(generate_calc_job, generate_inputs
 
     with pytest.raises(ValueError, match=r'specified mean field method invalid is not supported'):
         generate_calc_job(PyscfCalculation, inputs=inputs)
+
+
+def test_invalid_parameters_optimizer(generate_calc_job, generate_inputs_pyscf):
+    """Test validation of ``parameters.optimizer``."""
+    inputs = generate_inputs_pyscf(parameters=Dict({'optimizer': {}}))
+
+    with pytest.raises(ValueError, match=r'No solver specified in `optimizer` parameters'):
+        generate_calc_job(PyscfCalculation, inputs=inputs)
+
+    inputs = generate_inputs_pyscf(parameters=Dict({'optimizer': {'solver': 'solve-this'}}))
+
+    with pytest.raises(ValueError, match=r'Invalid solver `solve-this` specified in `optimizer` parameters'):
+        generate_calc_job(PyscfCalculation, inputs=inputs)


### PR DESCRIPTION
The `optimizer` dictionary requires a `solver` to be defined but this wasn't checked. If not defined, the job would still go through, defining an empty string and the script would simply fail causing the calculation job to be marked with exit code `ERROR_OUTPUT_RESULTS_MISSING`.

Here, the `parameters` validation is extended to check that the `solver` is defined if it contains the `optimizer` dictionary and that it is a valid solver. Currently implemented solvers are `geometric` and `berny`.