### PR TITLE
`PyscfCalculation`: Add support for writing FCIDUMP files

### DIFF
--- a/src/aiida_pyscf/calculations/templates/fcidump.py.j2
+++ b/src/aiida_pyscf/calculations/templates/fcidump.py.j2
@@ -1,0 +1,17 @@
+# Section: fcidump
+from pyscf.mcscf.casci import CASCI
+from pyscf.tools import fcidump
+
+for active_spaces, occupations in zip({{ fcidump.active_spaces }}, {{ fcidump.occupations }}):
+    casci = CASCI(mean_field_run, len(active_spaces), sum(occupations))
+    new_mo = casci.sort_mo(active_spaces)
+    one_integral, shift = casci.h1e_for_cas(new_mo)
+    two_integral = casci.get_h2eff(new_mo)
+    fcidump.from_integrals(
+        f"active_space_{'_'.join([str(index) for index in active_spaces])}.fcidump",
+        one_integral,
+        two_integral,
+        casci.ncas,
+        casci.nelecas,
+        nuc=shift
+    )

--- a/src/aiida_pyscf/calculations/templates/script.py.j2
+++ b/src/aiida_pyscf/calculations/templates/script.py.j2
@@ -21,6 +21,10 @@ def main():
     {% include 'pyscf/optimizer.py.j2' %}
     {% endif %}
 
+    {% if fcidump %}
+    {% include 'pyscf/fcidump.py.j2' %}
+    {% endif %}
+
     {% include 'pyscf/results.py.j2' %}
     {% endfilter %}
 

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -35,6 +35,7 @@ def main():
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
 
+
     # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -26,11 +26,7 @@ def main():
 
     # Section: Mean field
     from pyscf import scf
-    mean_field = scf.RHF(structure)
-    mean_field.xc = 'PBE'
-    mean_field.grids = {'level': 3}
-    mean_field.method = 'RHF'
-    mean_field.diis_start_cycle = 2
+    mean_field = scf.UKS(structure)
     mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run()
 
@@ -39,6 +35,23 @@ def main():
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
 
+    # Section: fcidump
+    from pyscf.mcscf.casci import CASCI
+    from pyscf.tools import fcidump
+
+    for active_spaces, occupations in zip([[5, 6], [5, 7]], [[1, 1], [1, 1]]):
+        casci = CASCI(mean_field_run, len(active_spaces), sum(occupations))
+        new_mo = casci.sort_mo(active_spaces)
+        one_integral, shift = casci.h1e_for_cas(new_mo)
+        two_integral = casci.get_h2eff(new_mo)
+        fcidump.from_integrals(
+            f"active_space_{'_'.join([str(index) for index in active_spaces])}.fcidump",
+            one_integral,
+            two_integral,
+            casci.ncas,
+            casci.nelecas,
+            nuc=shift
+        )
 
     # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -46,6 +46,7 @@ def main():
     results['timings']['optimizer'] = time.perf_counter() - optimizer_start
     results['optimized_coordinates'] = optimizer_run.atom_coords().tolist()
 
+
     # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 

--- a/tests/calculations/test_base/test_parameters_structure.pyr
+++ b/tests/calculations/test_base/test_parameters_structure.pyr
@@ -39,6 +39,7 @@ def main():
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
 
+
     # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,3 +68,24 @@ def test_pyscf_base_geometry_optimization(
         },
     )
     data_regression.check(parameters)
+
+
+def test_pyscf_base_fcidump(aiida_local_code_factory, generate_structure):
+    """Test a ``PyscfCalculation`` job with an ``fcidump`` calculation."""
+    code = aiida_local_code_factory('pyscf.base', 'python')
+    builder = code.get_builder()
+    builder.structure = generate_structure(formula='N2')
+    builder.parameters = orm.Dict({
+        'mean_field': {
+            'method': 'RHF'
+        },
+        'fcidump': {
+            'active_spaces': [[5, 6, 8, 9]],
+            'occupations': [[1, 1, 1, 1]]
+        }
+    })
+
+    results, node = engine.run_get_node(builder)
+    assert node.is_finished_ok
+    assert 'fcidump' in results
+    assert all(isinstance(node, orm.SinglefileData) for node in results['fcidump'].values())


### PR DESCRIPTION
To instruct the calculation to dump a representation of the Hamiltonian
to FCIDUMP files, add the `fcidump` dictionary to the `parameters` input:

    'fcidump': {
        'active_spaces': [[5, 6, 8, 9]],
        'occupations': [[1, 1, 1, 1]]
    }

The `active_spaces` and `occupations` keys are requires and each take a
list of list of integers. For each element in the list, a FCIDUMP file
is generated for the corresponding active spaces and the occupations of
the orbitals. The shape of the `active_spaces` and `occupations` array
has to be identical.

The generated FCIDUMP files are attached as `SinglefileData` output
nodes in the `fcidump` namespace, where the label is determined by the
corresponding active space, e.g, `active_space_5_6_8_9`.