### PR TITLE
`PyscfCalculation`: Ensure strings are rendered with quotes in templates

### DIFF
--- a/src/aiida_pyscf/calculations/base.py
+++ b/src/aiida_pyscf/calculations/base.py
@@ -109,6 +109,23 @@ class PyscfCalculation(CalcJob):
 
         return parameters
 
+    @classmethod
+    def filter_render_python(cls, value: t.Any) -> t.Any:
+        """Render the ``value`` in a template literally as it would be rendered in a Python script.
+
+        For now, it simply ensures that string variables are rendered with quotes as the default behavior of Jinja is to
+        strip these strings, since it is mostly intended to generate HTML markup and not Python code.
+        This filter can be registered in a template environment and then used as:
+
+            {{ variable|render_python }}
+
+        :param value: Any value that needs to be rendered literally.
+        :return: The rendered value
+        """
+        if isinstance(value, str):
+            return f"'{value}'"
+        return value
+
     def render_script(self) -> str:
         """Return the rendered input script.
 
@@ -118,6 +135,7 @@ class PyscfCalculation(CalcJob):
         environment.trim_blocks = True
         environment.lstrip_blocks = True
         environment.keep_trailing_newline = True
+        environment.filters['render_python'] = self.filter_render_python
         parameters = self.get_parameters()
 
         return environment.get_template('pyscf/script.py.j2').render(

--- a/src/aiida_pyscf/calculations/templates/mean_field.py.j2
+++ b/src/aiida_pyscf/calculations/templates/mean_field.py.j2
@@ -3,7 +3,7 @@ from pyscf import scf
 mean_field = scf.{{ mean_field.method | default('UKS') }}(structure)
 {% if mean_field %}
     {% for key, value in mean_field.items() %}
-mean_field.{{ key }} = {{ value|tojson }}
+mean_field.{{ key }} = {{ value|render_python }}
     {% endfor %}
 {% endif %}
 mean_field_start = time.perf_counter()

--- a/src/aiida_pyscf/calculations/templates/optimizer.py.j2
+++ b/src/aiida_pyscf/calculations/templates/optimizer.py.j2
@@ -2,7 +2,7 @@
 convergence_parameters = {}
 {% if optimizer.convergence_parameters %}
     {% for key, value in optimizer.convergence_parameters.items() %}
-convergence_parameters['{{ key }}'] = {{ value }}
+convergence_parameters['{{ key }}'] = {{ value|render_python }}
     {% endfor %}
 {% endif %}
 

--- a/src/aiida_pyscf/calculations/templates/structure.py.j2
+++ b/src/aiida_pyscf/calculations/templates/structure.py.j2
@@ -4,7 +4,7 @@ structure = gto.Mole()
 {% if structure %}
     {% for key, value in structure.items() %}
         {% if key != 'xyz' %}
-structure.{{ key }} = {{ value }}
+structure.{{ key }} = {{ value|render_python }}
         {% endif %}
     {% endfor %}
 {% endif %}

--- a/tests/calculations/test_base/test_filter_render_python.pyr
+++ b/tests/calculations/test_base/test_filter_render_python.pyr
@@ -1,0 +1,6 @@
+
+obj.bool = True
+obj.float = 1.0
+obj.integer = 1
+obj.string = 'string'
+obj.dictionary = {'a': 1, 'b': 1.0, 'c': 'str'}

--- a/tests/calculations/test_base/test_parameters_mean_field.pyr
+++ b/tests/calculations/test_base/test_parameters_mean_field.pyr
@@ -27,9 +27,9 @@ def main():
     # Section: Mean field
     from pyscf import scf
     mean_field = scf.RHF(structure)
-    mean_field.xc = "PBE"
-    mean_field.grids = {"level": 3}
-    mean_field.method = "RHF"
+    mean_field.xc = 'PBE'
+    mean_field.grids = {'level': 3}
+    mean_field.method = 'RHF'
     mean_field.diis_start_cycle = 2
     mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run()

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -36,6 +36,7 @@ def main():
 
     # Section: Optimizer
     convergence_parameters = {}
+    convergence_parameters['string'] = 'value'
     convergence_parameters['convergence_energy'] = 2.0
 
     optimizer_start = time.perf_counter()

--- a/tests/calculations/test_base/test_parameters_structure.pyr
+++ b/tests/calculations/test_base/test_parameters_structure.pyr
@@ -18,6 +18,7 @@ def main():
     structure = gto.Mole()
     structure.cart = True
     structure.spin = 2
+    structure.basis = {'H': 'cc-pvdz', 'O': 'sto-3g'}
     structure.charge = 1
     structure.unit = 'Ang'
     structure.atom = """


### PR DESCRIPTION
A number of the templates allow to set arbitrary attributes on an object instance within the template through a dictionary, e.g.:

    {% for key, value in structure.items() %}
    structure.{{ key }} = {{ value }}
    {% endfor %}

The problem is that if the `value` is a string, it would be stripped of its quotes. This would lead to a `NameError` in the rendered script when executed as it would be interpreted as a variable instead of a string, and the variable would most likely not be defined.

The reason for this is that Jinja is typically used to render HTML markup and not Python code. In the former, one would expect Python string to simply be rendered as text, i.e., without quotes.

As a solution, a custom filter is implemented `filter_render_python` which is attached to the `PyscfCalculation` as a classmethod. It is attached to the template environment which allows templates to use it as

    {% for key, value in structure.items() %}
    structure.{{ key }} = {{ value|render_python }}
    {% endfor %}

The filter simply renders all types as is, except for strings, where it literally wraps the value in single quotes.