### PR TITLE
`PyscfCalculation`: Add support for computing orbital cube files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,47 @@ print(results['fcidump']['active_space_5_6_7_8'].get_content())
   ...
 ```
 
+### Writing orbitals to CUBE files
+
+To instruct the calculation to dump a representation of molecular orbitals to CUBE files, add the `cubegen` dictionary to the `parameters` input:
+```python
+from ase.build import molecule
+from aiida.engine import run
+from aiida.orm import Dict, StructureData, load_code
+
+builder = load_code('pyscf').get_builder()
+builder.structure = StructureData(ase=molecule('N2'))
+builder.parameters = Dict({
+    'mean_field': {'method': 'RHF'},
+    'cubegen': {
+        'indices': [5, 6],
+        'parameters': {
+            'nx': 40,
+            'ny': 40,
+            'nz': 40,
+        }
+    }
+})
+results, node = run.get_node(builder)
+```
+The `indices` key has to be specified and takes a list of integers, indicating the indices of the molecular orbitals that should be written to file.
+Additional parameters can be provided in the `parameters` subdictionary (see the [PySCF documentation](https://pyscf.org/pyscf_api_docs/pyscf.tools.html?highlight=fcidump#module-pyscf.tools.cubegen) for details).
+
+The generated CUBE files are attached as `SinglefileData` output nodes in the `cubegen` namespace, where the label is determined by the corresponding molecular orbital index:
+```python
+print(results['cubegen']['mo_5'].get_content())
+Orbital value in real space (1/Bohr^3)
+PySCF Version: 2.1.1  Date: Sun Apr  2 15:59:19 2023
+    2   -3.000000   -3.000000   -4.067676
+   40    0.153846    0.000000    0.000000
+   40    0.000000    0.153846    0.000000
+   40    0.000000    0.000000    0.208599
+    7    0.000000    0.000000    0.000000    1.067676
+    7    0.000000    0.000000    0.000000   -1.067676
+ -1.10860E-04 -1.56874E-04 -2.16660E-04 -2.92099E-04 -3.84499E-04 -4.94299E-04
+ -6.20809E-04 -7.62048E-04 -9.14724E-04 -1.07439E-03 -1.23579E-03 -1.39331E-03
+  ...
+```
 
 ## Contributing
 

--- a/src/aiida_pyscf/calculations/templates/cubegen.py.j2
+++ b/src/aiida_pyscf/calculations/templates/cubegen.py.j2
@@ -1,0 +1,11 @@
+from pyscf.tools import cubegen
+
+{% if optimizer %}
+hf = optimizer_run
+{% else %}
+hf = mean_field_run
+{% endif %}
+
+for index in {{ cubegen.indices }}:
+    filename = f'mo_{index}.cube'
+    cubegen.orbital(hf.mol, filename, hf.mo_coeff[:,index], **{{ cubegen.parameters or {} }})

--- a/src/aiida_pyscf/calculations/templates/script.py.j2
+++ b/src/aiida_pyscf/calculations/templates/script.py.j2
@@ -21,6 +21,10 @@ def main():
     {% include 'pyscf/optimizer.py.j2' %}
     {% endif %}
 
+    {% if cubegen %}
+    {% include 'pyscf/cubegen.py.j2' %}
+    {% endif %}
+
     {% if fcidump %}
     {% include 'pyscf/fcidump.py.j2' %}
     {% endif %}

--- a/src/aiida_pyscf/parsers/base.py
+++ b/src/aiida_pyscf/parsers/base.py
@@ -55,6 +55,9 @@ class PyscfParser(Parser):
             parsed_json['forces_units'] = 'eV/Å'
 
         if dirpath_temporary:
+            for filepath_cubegen in dirpath_temporary.glob('*.cube'):
+                self.out(f'cubegen.{filepath_cubegen.stem}', SinglefileData(filepath_cubegen))
+
             for filepath_fcidump in dirpath_temporary.glob('*.fcidump'):
                 self.out(f'fcidump.{filepath_fcidump.stem}', SinglefileData(filepath_fcidump))
 

--- a/tests/calculations/test_base.py
+++ b/tests/calculations/test_base.py
@@ -104,6 +104,26 @@ def test_parameters_optimizer(generate_calc_job, generate_inputs_pyscf, file_reg
     file_regression.check(content_input_file, encoding='utf-8', extension='.pyr')
 
 
+def test_parameters_cubegen(generate_calc_job, generate_inputs_pyscf, file_regression):
+    """Test the ``cubegen`` key of the ``parameters`` input."""
+    parameters = {
+        'cubegen': {
+            'indices': [5, 6],
+            'parameters': {
+                'nx': 40,
+                'ny': 40,
+                'nz': 40,
+                'margin': 3.0,
+            }
+        },
+    }
+    inputs = generate_inputs_pyscf(parameters=Dict(parameters))
+    tmp_path, _ = generate_calc_job(PyscfCalculation, inputs=inputs)
+
+    content_input_file = (tmp_path / PyscfCalculation.FILENAME_SCRIPT).read_text()
+    file_regression.check(content_input_file, encoding='utf-8', extension='.pyr')
+
+
 def test_parameters_fcidump(generate_calc_job, generate_inputs_pyscf, file_regression):
     """Test the ``fcidump`` key of the ``parameters`` input."""
     parameters = {
@@ -140,6 +160,20 @@ def test_invalid_parameters_optimizer(generate_calc_job, generate_inputs_pyscf, 
     """Test validation of ``parameters.optimizer``."""
     with pytest.raises(ValueError, match=expected):
         generate_calc_job(PyscfCalculation, inputs=generate_inputs_pyscf(parameters=Dict({'optimizer': parameters})))
+
+
+@pytest.mark.parametrize(
+    'parameters, expected', (
+        ({}, 'If the `cubegen` key is specified, the `indices` key has to be defined with a list of indices.'),
+        ({
+            'indices': 1
+        }, r'The `cubegen.indices` parameter should be a list of integers, but got:.*'),
+    )
+)
+def test_invalid_parameters_cubegen(generate_calc_job, generate_inputs_pyscf, parameters, expected):
+    """Test validation of ``parameters.cubegen``."""
+    with pytest.raises(ValueError, match=expected):
+        generate_calc_job(PyscfCalculation, inputs=generate_inputs_pyscf(parameters=Dict({'cubegen': parameters})))
 
 
 @pytest.mark.parametrize(

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -36,6 +36,7 @@ def main():
 
 
 
+
     # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 

--- a/tests/calculations/test_base/test_parameters_cubegen.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen.pyr
@@ -26,11 +26,7 @@ def main():
 
     # Section: Mean field
     from pyscf import scf
-    mean_field = scf.RHF(structure)
-    mean_field.xc = 'PBE'
-    mean_field.grids = {'level': 3}
-    mean_field.method = 'RHF'
-    mean_field.diis_start_cycle = 2
+    mean_field = scf.UKS(structure)
     mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run()
 
@@ -39,6 +35,13 @@ def main():
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
 
+    from pyscf.tools import cubegen
+
+    hf = mean_field_run
+
+    for index in [5, 6]:
+        filename = f'mo_{index}.cube'
+        cubegen.orbital(hf.mol, filename, hf.mo_coeff[:,index], **{'nx': 40, 'ny': 40, 'nz': 40, 'margin': 3.0})
 
 
     # Section: Results

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -35,6 +35,7 @@ def main():
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
 
 
+
     # Section: fcidump
     from pyscf.mcscf.casci import CASCI
     from pyscf.tools import fcidump

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -47,6 +47,7 @@ def main():
     results['optimized_coordinates'] = optimizer_run.atom_coords().tolist()
 
 
+
     # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 

--- a/tests/calculations/test_base/test_parameters_structure.pyr
+++ b/tests/calculations/test_base/test_parameters_structure.pyr
@@ -40,6 +40,7 @@ def main():
 
 
 
+
     # Section: Results
     results['timings']['total'] = time.perf_counter() - time_start
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -70,6 +70,26 @@ def test_pyscf_base_geometry_optimization(
     data_regression.check(parameters)
 
 
+def test_pyscf_base_cubegen(aiida_local_code_factory, generate_structure):
+    """Test a ``PyscfCalculation`` job with an ``cubegen`` calculation."""
+    code = aiida_local_code_factory('pyscf.base', 'python')
+    builder = code.get_builder()
+    builder.structure = generate_structure(formula='N2')
+    builder.parameters = orm.Dict({
+        'mean_field': {
+            'method': 'RHF'
+        },
+        'cubegen': {
+            'indices': [5, 6],
+        }
+    })
+
+    results, node = engine.run_get_node(builder)
+    assert node.is_finished_ok
+    assert 'cubegen' in results
+    assert all(isinstance(node, orm.SinglefileData) for node in results['cubegen'].values())
+
+
 def test_pyscf_base_fcidump(aiida_local_code_factory, generate_structure):
     """Test a ``PyscfCalculation`` job with an ``fcidump`` calculation."""
     code = aiida_local_code_factory('pyscf.base', 'python')


### PR DESCRIPTION
To instruct the calculation to dump a representation of molecular orbitals to CUBE files, add the `cubegen` dictionary to the `parameters` input:

    'cubegen': {
        'indices': [5, 6],
        'parameters': {
            'nx': 40,
            'ny': 40,
            'nz': 40,
        }
    }

The `indices` key has to be specified and takes a list of integers, indicating the indices of the molecular orbitals that should be written to file. The generated CUBE files are attached as `SinglefileData` output nodes in the `cubegen` namespace, where the label is determined by the corresponding molecular orbital index, e.g, `mo_5`.