### PR TITLE
CI: Update `pip` and install `wheel`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,9 @@ jobs:
                 cache: 'pip'
                 cache-dependency-path: pyproject.toml
 
+        -   name: Update pip and install wheel
+            run: pip install -U pip wheel
+
         -   name: Install Python package and dependencies
             run: pip install -e .[pre-commit,tests]
 
@@ -73,6 +76,9 @@ jobs:
 
         -   name: Install system dependencies
             run: sudo apt update && sudo apt install postgresql
+
+        -   name: Update pip and install wheel
+            run: pip install -U pip wheel
 
         -   name: Install Python package and dependencies
             run: pip install -e .[tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
                 cache: 'pip'
                 cache-dependency-path: pyproject.toml
 
+        -   name: Update pip and install wheel
+            run: pip install -U pip wheel
+
         -   name: Install Python package and dependencies
             run: pip install -e .[pre-commit,tests]
 
@@ -51,6 +54,9 @@ jobs:
 
         -   name: Install system dependencies
             run: sudo apt update && sudo apt install postgresql
+
+        -   name: Update pip and install wheel
+            run: pip install -U pip wheel
 
         -   name: Install Python package and dependencies
             run: pip install -e .[tests]


### PR DESCRIPTION
Without `wheel` installed, installing a package that doesn't have the modern `pyproject.toml` yet to specify build dependencies, `pip` will build the package from the legacy `setup.py`. This can take significantly more time than installing from a pre-built wheel.