### PR TITLE
`PyscfCalculation`: Remove redirection of stderr to separate file

### DIFF
--- a/src/aiida_pyscf/calculations/base.py
+++ b/src/aiida_pyscf/calculations/base.py
@@ -22,7 +22,6 @@ class PyscfCalculation(CalcJob):
     """``CalcJob`` plugin for PySCF."""
 
     FILENAME_SCRIPT: str = 'script.py'
-    FILENAME_STDERR: str = 'aiida.err'
     FILENAME_STDOUT: str = 'aiida.out'
     FILENAME_RESULTS: str = 'results.json'
     FILEPATH_LOG_INI: pathlib.Path = pathlib.Path(__file__).parent / 'templates' / 'geometric_log.ini'
@@ -70,8 +69,7 @@ class PyscfCalculation(CalcJob):
         spec.output_namespace('fcidump', valid_type=SinglefileData, required=False, help='Computed fcidump files.')
 
         spec.exit_code(302, 'ERROR_OUTPUT_STDOUT_MISSING', message='The stdout output file was not retrieved.')
-        spec.exit_code(303, 'ERROR_OUTPUT_STDERR_MISSING', message='The stderr output file was not retrieved.')
-        spec.exit_code(304, 'ERROR_OUTPUT_RESULTS_MISSING', message='The results JSON file was not retrieved.')
+        spec.exit_code(303, 'ERROR_OUTPUT_RESULTS_MISSING', message='The results JSON file was not retrieved.')
 
     @classmethod
     def validate_parameters(cls, value: Dict | None, _) -> str | None:  # pylint: disable=too-many-return-statements,too-many-branches
@@ -211,7 +209,6 @@ class PyscfCalculation(CalcJob):
         codeinfo = CodeInfo()
         codeinfo.cmdline_params = [self.FILENAME_SCRIPT]
         codeinfo.code_uuid = self.inputs.code.uuid  # type: ignore[union-attr]
-        codeinfo.stderr_name = self.FILENAME_STDERR
         codeinfo.stdout_name = self.FILENAME_STDOUT
 
         calcinfo = CalcInfo()
@@ -219,7 +216,6 @@ class PyscfCalculation(CalcJob):
         calcinfo.retrieve_temporary_list = []
         calcinfo.retrieve_list = [
             self.FILENAME_RESULTS,
-            self.FILENAME_STDERR,
             self.FILENAME_STDOUT,
         ]
 

--- a/src/aiida_pyscf/parsers/base.py
+++ b/src/aiida_pyscf/parsers/base.py
@@ -27,14 +27,11 @@ class PyscfParser(Parser):
         dirpath_temporary = pathlib.Path(retrieved_temporary_folder) if retrieved_temporary_folder else None
 
         for filename, exit_code in (
-            (PyscfCalculation.FILENAME_STDERR, PyscfCalculation.exit_codes.ERROR_OUTPUT_STDERR_MISSING),
             (PyscfCalculation.FILENAME_STDOUT, PyscfCalculation.exit_codes.ERROR_OUTPUT_STDOUT_MISSING),
+            (PyscfCalculation.FILENAME_RESULTS, PyscfCalculation.exit_codes.ERROR_OUTPUT_RESULTS_MISSING),
         ):
             if filename not in files_retrieved:
                 return exit_code
-
-        if PyscfCalculation.FILENAME_RESULTS not in files_retrieved:
-            return self.exit_codes.ERROR_OUTPUT_RESULTS_MISSING
 
         with self.retrieved.open(PyscfCalculation.FILENAME_RESULTS, 'rb') as handle:
             parsed_json = json.load(handle)

--- a/tests/calculations/test_base.py
+++ b/tests/calculations/test_base.py
@@ -44,7 +44,6 @@ def test_default(generate_calc_job, generate_inputs_pyscf, file_regression):
 
     assert sorted(calc_info.retrieve_list) == sorted([
         PyscfCalculation.FILENAME_RESULTS,
-        PyscfCalculation.FILENAME_STDERR,
         PyscfCalculation.FILENAME_STDOUT,
     ])
 


### PR DESCRIPTION
The redirection serves no real purpose as data written to stderr is already captured by `_scheduler-stderr.txt` which is setup by `aiida-core`. Certain tools, such as `verdi process report` are integrated with this file but not our custom `aiida.err`. Since we are anyway not parsing it yet, there is no real point in having a seperate custom stderr file.