### PR TITLE
`PyscfCalculation`: Add the `checkpoint` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,14 @@ PySCF Version: 2.1.1  Date: Sun Apr  2 15:59:19 2023
 
 The plugin will automatically instruct PySCF to write a checkpoint file.
 If the calculation did not converge, it will finish with exit status `410` and the checkpoint file is attached as a `SinglefileData` as the `checkpoint` output node.
-This node can then be passed as input to a new calculation to restart from the checkpoint.
+This node can then be passed as input to a new calculation to restart from the checkpoint:
+```python
+failed_calculation = load_node(IDENTIFIER)
+builder = failed_calculation.get_builder_restart()
+builder.checkpoint = failed_calculation.outputs.checkpoint
+submit(builder)
+```
+The plugin will write the checkpoint file of the failed calculation to the working directory such that PySCF can start of from there.
 
 ## Contributing
 

--- a/src/aiida_pyscf/calculations/templates/mean_field.py.j2
+++ b/src/aiida_pyscf/calculations/templates/mean_field.py.j2
@@ -3,13 +3,18 @@ from pyscf import scf
 mean_field = scf.{{ mean_field.method }}(structure)
 {% if mean_field %}
     {% for key, value in mean_field.items() %}
-        {% if key != 'method' %}
+        {% if key not in ['method', 'checkpoint'] %}
 mean_field.{{ key }} = {{ value|render_python }}
         {% endif %}
     {% endfor %}
+    {% if 'checkpoint' in mean_field %}
+density_matrix = mean_field.from_chk({{ mean_field.checkpoint|render_python }})
+    {% else %}
+density_matrix = None
+    {% endif %}
 {% endif %}
 mean_field_start = time.perf_counter()
-mean_field_run = mean_field.run()
+mean_field_run = mean_field.run(density_matrix)
 
 results['is_converged'] = mean_field_run.converged
 results['timings']['mean_field'] = time.perf_counter() - mean_field_start

--- a/tests/calculations/test_base/test_checkpoint.pyr
+++ b/tests/calculations/test_base/test_checkpoint.pyr
@@ -16,10 +16,6 @@ def main():
     # Section: Structure definition
     from pyscf import gto
     structure = gto.Mole()
-    structure.cart = True
-    structure.spin = 2
-    structure.basis = {'H': 'cc-pvdz', 'O': 'sto-3g'}
-    structure.charge = 1
     structure.unit = 'Ang'
     structure.atom = """
     O       0.000000000000000      0.000000000000000      0.119262000000000
@@ -32,7 +28,7 @@ def main():
     from pyscf import scf
     mean_field = scf.RHF(structure)
     mean_field.chkfile = 'checkpoint.chk'
-    density_matrix = None
+    density_matrix = mean_field.from_chk('restart.chk')
     mean_field_start = time.perf_counter()
     mean_field_run = mean_field.run(density_matrix)
 

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -28,8 +28,9 @@ def main():
     from pyscf import scf
     mean_field = scf.RHF(structure)
     mean_field.chkfile = 'checkpoint.chk'
+    density_matrix = None
     mean_field_start = time.perf_counter()
-    mean_field_run = mean_field.run()
+    mean_field_run = mean_field.run(density_matrix)
 
     results['is_converged'] = mean_field_run.converged
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start

--- a/tests/calculations/test_base/test_parameters_cubegen.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen.pyr
@@ -28,8 +28,9 @@ def main():
     from pyscf import scf
     mean_field = scf.RHF(structure)
     mean_field.chkfile = 'checkpoint.chk'
+    density_matrix = None
     mean_field_start = time.perf_counter()
-    mean_field_run = mean_field.run()
+    mean_field_run = mean_field.run(density_matrix)
 
     results['is_converged'] = mean_field_run.converged
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -28,8 +28,9 @@ def main():
     from pyscf import scf
     mean_field = scf.RHF(structure)
     mean_field.chkfile = 'checkpoint.chk'
+    density_matrix = None
     mean_field_start = time.perf_counter()
-    mean_field_run = mean_field.run()
+    mean_field_run = mean_field.run(density_matrix)
 
     results['is_converged'] = mean_field_run.converged
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start

--- a/tests/calculations/test_base/test_parameters_mean_field.pyr
+++ b/tests/calculations/test_base/test_parameters_mean_field.pyr
@@ -31,8 +31,9 @@ def main():
     mean_field.grids = {'level': 3}
     mean_field.diis_start_cycle = 2
     mean_field.chkfile = 'checkpoint.chk'
+    density_matrix = None
     mean_field_start = time.perf_counter()
-    mean_field_run = mean_field.run()
+    mean_field_run = mean_field.run(density_matrix)
 
     results['is_converged'] = mean_field_run.converged
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -28,8 +28,9 @@ def main():
     from pyscf import scf
     mean_field = scf.RHF(structure)
     mean_field.chkfile = 'checkpoint.chk'
+    density_matrix = None
     mean_field_start = time.perf_counter()
-    mean_field_run = mean_field.run()
+    mean_field_run = mean_field.run(density_matrix)
 
     results['is_converged'] = mean_field_run.converged
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start


### PR DESCRIPTION
This input takes a `SinglefileData` that contains the checkpoint file of
a previously completed calculation that failed to converge
electronically. The file is written to the working directory of the
calculation and the generated script ensures that the `mean_field` object
is instantiated with the density matrix reconstructed from the file.
This completes the basic restart functionality for the electronic
convergence cycle.