### PR TITLE
`PyscfBaseWorkChain`: Handle failed electronic convergence

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 import collections
+import io
 import pathlib
 
 from aiida.common.folders import Folder
 from aiida.common.links import LinkType
 from aiida.engine.utils import instantiate_process
 from aiida.manage.manager import get_manager
-from aiida.orm import CalcJobNode, Dict, FolderData, StructureData
+from aiida.orm import CalcJobNode, Dict, FolderData, SinglefileData, StructureData
 from aiida.plugins import ParserFactory, WorkflowFactory
 from ase.build import molecule
 from plumpy import ProcessState
@@ -160,6 +161,10 @@ def generate_workchain_pyscf_base(generate_workchain, generate_inputs_pyscf, gen
         if exit_code is not None:
             node.set_process_state(ProcessState.FINISHED)
             node.set_exit_status(exit_code.status)
+
+            checkpoint = SinglefileData(io.StringIO('content'))
+            checkpoint.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='checkpoint')
+            checkpoint.store()
 
         return process
 

--- a/tests/workflows/test_base.py
+++ b/tests/workflows/test_base.py
@@ -25,3 +25,16 @@ def test_handle_unrecoverable_failure(generate_workchain_pyscf_base):
 
     result = process.inspect_process()
     assert result == PyscfBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
+
+
+def test_handle_electronic_convergence_not_reached(generate_workchain_pyscf_base):
+    """Test ``PyscfBaseWorkChain.handle_electronic_convergence_not_reached``."""
+    process = generate_workchain_pyscf_base(
+        exit_code=PyscfCalculation.exit_codes.ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED
+    )
+    process.setup()
+
+    result = process.handle_electronic_convergence_not_reached(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert process.ctx.inputs.checkpoint


### PR DESCRIPTION
If calculation fails with `ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED` the work chain automatically restarts it, passing the `checkpoint` output node as the `checkpoint` input. This will cause PySCF to restart from the checkpoint that was written at the end of the previous calculation which should increase the chances of the next calculation of converging.