### PR TITLE
`PyscfParser`: Do not override scheduler exit code if set

### DIFF
--- a/src/aiida_pyscf/parsers/base.py
+++ b/src/aiida_pyscf/parsers/base.py
@@ -31,6 +31,9 @@ class PyscfParser(Parser):
             (PyscfCalculation.FILENAME_RESULTS, PyscfCalculation.exit_codes.ERROR_OUTPUT_RESULTS_MISSING),
         ):
             if filename not in files_retrieved:
+                # If an exit status has already been set by the scheduler, keep that by returning instead of overriding.
+                if self.node.exit_status is not None:
+                    return ExitCode(self.node.exit_status, self.node.exit_message)
                 return exit_code
 
         with self.retrieved.open(PyscfCalculation.FILENAME_RESULTS, 'rb') as handle:

--- a/tests/parsers/fixtures/base/failed_out_of_walltime/_scheduler-stderr.txt
+++ b/tests/parsers/fixtures/base/failed_out_of_walltime/_scheduler-stderr.txt
@@ -1,0 +1,1 @@
+slurmstepd: error: *** JOB 12225 ON node CANCELLED AT 2023-04-09T19:48:15 DUE TO TIME LIMIT ***

--- a/tests/parsers/test_base.py
+++ b/tests/parsers/test_base.py
@@ -30,6 +30,17 @@ def test_relax(generate_calc_job_node, generate_parser, generate_structure, data
     data_regression.check({'structure': results['structure'].base.attributes.all})
 
 
+def test_failed_out_of_walltime(generate_calc_job_node, generate_parser):
+    """Test parsing a retrieved folder where the job got interrupted by the scheduler because it ran out of walltime."""
+    node = generate_calc_job_node('pyscf.base', 'failed_out_of_walltime')
+    node.set_exit_status(PyscfCalculation.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME.status)
+    parser = generate_parser('pyscf.base')
+    _, calcfunction = parser.parse_from_node(node, store_provenance=False)
+
+    assert calcfunction.is_failed
+    assert calcfunction.exit_status == PyscfCalculation.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME.status
+
+
 def test_failed_missing_result(generate_calc_job_node, generate_parser):
     """Test parsing a retrieved folder where the result output file is missing."""
     node = generate_calc_job_node('pyscf.base', 'failed_missing_result')


### PR DESCRIPTION
Before the parser is called, the scheduler plugin gets the chance to parse the scheduler output and set an exit code if a problem was detected, such as the job being killed due to it running out of memory or walltime.

In this case, the `PyscfParser` should only return an exit code if it has a more specific exit code. For example, in the case of the job being killed as a result of an out of walltime error, it is likely that the results file will not be in the retrieved folder, but the corresponding exit code is less useful then the `ERROR_SCHEDULER_OUT_OF_WALLTIME` one that will have been set by the scheduler. In these cases, the scheduler exit code is kept by returning it, instead of overriding it.