### PR TITLE
`PyscfBaseWorkChain`: Handle `ERROR_SCHEDULER_OUT_OF_WALLTIME`

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,8 @@ PyscfBaseWorkChain<30126> Finished [0] [2:results]
 ```
 The following error modes are currently handled by the `PyscfBaseWorkChain`:
 
-* Electronic convergence not achieved
+* \[410\]: Electronic convergence not achieved: The calculation will be restarted from the last checkpoint
+* \[120\]: Out of walltime: The calculation will be restarted from the last checkpoint if available, otherwise the work chain is aborted
 
 
 ## Contributing

--- a/tests/workflows/test_base.py
+++ b/tests/workflows/test_base.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_pyscf.workflows.base` module."""
+import io
+
 from aiida.engine import ProcessHandlerReport
+from aiida.orm import SinglefileData
 
 from aiida_pyscf.calculations.base import PyscfCalculation
 from aiida_pyscf.workflows.base import PyscfBaseWorkChain
@@ -30,7 +33,8 @@ def test_handle_unrecoverable_failure(generate_workchain_pyscf_base):
 def test_handle_electronic_convergence_not_reached(generate_workchain_pyscf_base):
     """Test ``PyscfBaseWorkChain.handle_electronic_convergence_not_reached``."""
     process = generate_workchain_pyscf_base(
-        exit_code=PyscfCalculation.exit_codes.ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED
+        exit_code=PyscfCalculation.exit_codes.ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED,
+        outputs={'checkpoint': SinglefileData(io.StringIO('dummy checkpoint'))},
     )
     process.setup()
 
@@ -38,3 +42,27 @@ def test_handle_electronic_convergence_not_reached(generate_workchain_pyscf_base
     assert isinstance(result, ProcessHandlerReport)
     assert result.do_break
     assert process.ctx.inputs.checkpoint
+
+
+def test_handle_out_of_walltime(generate_workchain_pyscf_base):
+    """Test ``PyscfBaseWorkChain.handle_out_of_walltime``."""
+    process = generate_workchain_pyscf_base(
+        exit_code=PyscfCalculation.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME,
+        outputs={'checkpoint': SinglefileData(io.StringIO('dummy checkpoint'))},
+    )
+    process.setup()
+
+    # If the failed node has a ``checkpoint`` output, it should restart from that.
+    result = process.handle_out_of_walltime(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert process.ctx.inputs.checkpoint
+
+    process = generate_workchain_pyscf_base(exit_code=PyscfCalculation.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME)
+    process.setup()
+
+    # If the failed node has no ``checkpoint`` output, the work chain should abort.
+    result = process.handle_out_of_walltime(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code.status == PyscfBaseWorkChain.exit_codes.ERROR_NO_CHECKPOINT_TO_RESTART.status


### PR DESCRIPTION
The process handler triggers on a `ERROR_SCHEDULER_OUT_OF_WALLTIME`. If the failed calc job node has a `checkpoint` output, that is set as an input for the next calculation and it is restarted. If no checkpoint is available, the work chain is aborted, because it means restarting from scratch and the likelihood of it running out of walltime once again are very high, and so this would be a waste of resources.