### PR TITLE
`PyscfBaseWorkChain`: Handle `ERROR_SCHEDULER_NODE_FAILURE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,10 @@ PyscfBaseWorkChain<30126> Finished [0] [2:results]
 ```
 The following error modes are currently handled by the `PyscfBaseWorkChain`:
 
-* \[120\]: Out of walltime: The calculation will be restarted from the last checkpoint if available, otherwise the work chain is aborted
-* \[410\]: Electronic convergence not achieved: The calculation will be restarted from the last checkpoint
-* \[500\]: Ionic convergence not achieved: The geometry optmizization did not converge, calculation will be restarted from the last checkpoint and structure
+* `120`: Out of walltime: The calculation will be restarted from the last checkpoint if available, otherwise the work chain is aborted
+* `140`: Node failure: The calculation will be restarted from the last checkpoint
+* `410`: Electronic convergence not achieved: The calculation will be restarted from the last checkpoint
+* `500`: Ionic convergence not achieved: The geometry optmizization did not converge, calculation will be restarted from the last checkpoint and structure
 
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ['aiida', 'workflows', 'pyscf']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core[atomic_tools]~=2.1',
+    'aiida-core[atomic_tools]~=2.3',
     'numpy',
     'pint',
     'pyscf[geomopt]~=2.2',


### PR DESCRIPTION
The process handler triggers on a `ERROR_SCHEDULER_NODE_FAILURE`. These can sometimes be caused by transient problems and so simply restarting may automatically "fix" the problem. If the failed calc job node has a `checkpoint` output, that is set as an input for the next calculation and it is restarted. If no checkpoint is available, the work chain is simply restarted from the last inputs set in the context.