### PR TITLE
`PyscfCalculation`: Fix bug in script if SCF does not converge

### DIFF
--- a/src/aiida_pyscf/calculations/templates/mean_field.py.j2
+++ b/src/aiida_pyscf/calculations/templates/mean_field.py.j2
@@ -20,7 +20,11 @@ results['is_converged'] = mean_field_run.converged
 results['timings']['mean_field'] = time.perf_counter() - mean_field_start
 results['total_energy'] = mean_field_run.e_tot
 results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-results['molecular_orbitals'] = {}
-results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-results['molecular_orbitals']['labels'] = structure.ao_labels()
-results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+if mean_field_run.converged:
+    results['molecular_orbitals'] = {}
+    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+    results['molecular_orbitals']['labels'] = structure.ao_labels()
+    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+else:
+    write_results_and_exit(results)

--- a/src/aiida_pyscf/calculations/templates/results.py.j2
+++ b/src/aiida_pyscf/calculations/templates/results.py.j2
@@ -1,5 +1,11 @@
 # Section: Results
-results['timings']['total'] = time.perf_counter() - time_start
+def write_results_and_exit(results):
+    import json
+    import sys
 
-with open('{{ results.filename_output }}', 'w') as handle:
-    json.dump(results, handle)
+    results['timings']['total'] = time.perf_counter() - time_start
+
+    with open('{{ results.filename_output }}', 'w') as handle:
+        json.dump(results, handle)
+
+    sys.exit(0)

--- a/src/aiida_pyscf/calculations/templates/script.py.j2
+++ b/src/aiida_pyscf/calculations/templates/script.py.j2
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -13,6 +12,8 @@ def main():
     time_start = time.perf_counter()
 
     {% filter indent(width=4) +%}
+    {% include 'pyscf/results.py.j2' %}
+
     {% include 'pyscf/structure.py.j2' %}
 
     {% include 'pyscf/mean_field.py.j2' %}
@@ -28,9 +29,9 @@ def main():
     {% if fcidump %}
     {% include 'pyscf/fcidump.py.j2' %}
     {% endif %}
-
-    {% include 'pyscf/results.py.j2' %}
     {% endfilter %}
+
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_checkpoint.pyr
+++ b/tests/calculations/test_base/test_checkpoint.pyr
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -12,6 +11,18 @@ def main():
 
     time_start = time.perf_counter()
 
+
+    # Section: Results
+    def write_results_and_exit(results):
+        import json
+        import sys
+
+        results['timings']['total'] = time.perf_counter() - time_start
+
+        with open('results.json', 'w') as handle:
+            json.dump(results, handle)
+
+        sys.exit(0)
 
     # Section: Structure definition
     from pyscf import gto
@@ -36,19 +47,19 @@ def main():
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-    results['molecular_orbitals'] = {}
-    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-    results['molecular_orbitals']['labels'] = structure.ao_labels()
-    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+    if mean_field_run.converged:
+        results['molecular_orbitals'] = {}
+        results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+        results['molecular_orbitals']['labels'] = structure.ao_labels()
+        results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+    else:
+        write_results_and_exit(results)
 
 
 
 
-    # Section: Results
-    results['timings']['total'] = time.perf_counter() - time_start
-
-    with open('results.json', 'w') as handle:
-        json.dump(results, handle)
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -12,6 +11,18 @@ def main():
 
     time_start = time.perf_counter()
 
+
+    # Section: Results
+    def write_results_and_exit(results):
+        import json
+        import sys
+
+        results['timings']['total'] = time.perf_counter() - time_start
+
+        with open('results.json', 'w') as handle:
+            json.dump(results, handle)
+
+        sys.exit(0)
 
     # Section: Structure definition
     from pyscf import gto
@@ -36,19 +47,19 @@ def main():
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-    results['molecular_orbitals'] = {}
-    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-    results['molecular_orbitals']['labels'] = structure.ao_labels()
-    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+    if mean_field_run.converged:
+        results['molecular_orbitals'] = {}
+        results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+        results['molecular_orbitals']['labels'] = structure.ao_labels()
+        results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+    else:
+        write_results_and_exit(results)
 
 
 
 
-    # Section: Results
-    results['timings']['total'] = time.perf_counter() - time_start
-
-    with open('results.json', 'w') as handle:
-        json.dump(results, handle)
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_cubegen.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen.pyr
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -12,6 +11,18 @@ def main():
 
     time_start = time.perf_counter()
 
+
+    # Section: Results
+    def write_results_and_exit(results):
+        import json
+        import sys
+
+        results['timings']['total'] = time.perf_counter() - time_start
+
+        with open('results.json', 'w') as handle:
+            json.dump(results, handle)
+
+        sys.exit(0)
 
     # Section: Structure definition
     from pyscf import gto
@@ -36,10 +47,14 @@ def main():
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-    results['molecular_orbitals'] = {}
-    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-    results['molecular_orbitals']['labels'] = structure.ao_labels()
-    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+    if mean_field_run.converged:
+        results['molecular_orbitals'] = {}
+        results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+        results['molecular_orbitals']['labels'] = structure.ao_labels()
+        results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+    else:
+        write_results_and_exit(results)
 
 
     from pyscf.tools import cubegen
@@ -51,11 +66,7 @@ def main():
         cubegen.orbital(hf.mol, filename, hf.mo_coeff[:,index], **{'nx': 40, 'ny': 40, 'nz': 40, 'margin': 3.0})
 
 
-    # Section: Results
-    results['timings']['total'] = time.perf_counter() - time_start
-
-    with open('results.json', 'w') as handle:
-        json.dump(results, handle)
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -12,6 +11,18 @@ def main():
 
     time_start = time.perf_counter()
 
+
+    # Section: Results
+    def write_results_and_exit(results):
+        import json
+        import sys
+
+        results['timings']['total'] = time.perf_counter() - time_start
+
+        with open('results.json', 'w') as handle:
+            json.dump(results, handle)
+
+        sys.exit(0)
 
     # Section: Structure definition
     from pyscf import gto
@@ -36,10 +47,14 @@ def main():
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-    results['molecular_orbitals'] = {}
-    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-    results['molecular_orbitals']['labels'] = structure.ao_labels()
-    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+    if mean_field_run.converged:
+        results['molecular_orbitals'] = {}
+        results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+        results['molecular_orbitals']['labels'] = structure.ao_labels()
+        results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+    else:
+        write_results_and_exit(results)
 
 
 
@@ -61,11 +76,7 @@ def main():
             nuc=shift
         )
 
-    # Section: Results
-    results['timings']['total'] = time.perf_counter() - time_start
-
-    with open('results.json', 'w') as handle:
-        json.dump(results, handle)
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_mean_field.pyr
+++ b/tests/calculations/test_base/test_parameters_mean_field.pyr
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -12,6 +11,18 @@ def main():
 
     time_start = time.perf_counter()
 
+
+    # Section: Results
+    def write_results_and_exit(results):
+        import json
+        import sys
+
+        results['timings']['total'] = time.perf_counter() - time_start
+
+        with open('results.json', 'w') as handle:
+            json.dump(results, handle)
+
+        sys.exit(0)
 
     # Section: Structure definition
     from pyscf import gto
@@ -39,19 +50,19 @@ def main():
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-    results['molecular_orbitals'] = {}
-    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-    results['molecular_orbitals']['labels'] = structure.ao_labels()
-    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+    if mean_field_run.converged:
+        results['molecular_orbitals'] = {}
+        results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+        results['molecular_orbitals']['labels'] = structure.ao_labels()
+        results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+    else:
+        write_results_and_exit(results)
 
 
 
 
-    # Section: Results
-    results['timings']['total'] = time.perf_counter() - time_start
-
-    with open('results.json', 'w') as handle:
-        json.dump(results, handle)
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -12,6 +11,18 @@ def main():
 
     time_start = time.perf_counter()
 
+
+    # Section: Results
+    def write_results_and_exit(results):
+        import json
+        import sys
+
+        results['timings']['total'] = time.perf_counter() - time_start
+
+        with open('results.json', 'w') as handle:
+            json.dump(results, handle)
+
+        sys.exit(0)
 
     # Section: Structure definition
     from pyscf import gto
@@ -36,10 +47,14 @@ def main():
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-    results['molecular_orbitals'] = {}
-    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-    results['molecular_orbitals']['labels'] = structure.ao_labels()
-    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+    if mean_field_run.converged:
+        results['molecular_orbitals'] = {}
+        results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+        results['molecular_orbitals']['labels'] = structure.ao_labels()
+        results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+    else:
+        write_results_and_exit(results)
 
     # Section: Optimizer
     convergence_parameters = {}
@@ -56,11 +71,7 @@ def main():
 
 
 
-    # Section: Results
-    results['timings']['total'] = time.perf_counter() - time_start
-
-    with open('results.json', 'w') as handle:
-        json.dump(results, handle)
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':

--- a/tests/calculations/test_base/test_parameters_structure.pyr
+++ b/tests/calculations/test_base/test_parameters_structure.pyr
@@ -3,7 +3,6 @@
 
 
 def main():
-    import json
     import time
 
     results = {
@@ -12,6 +11,18 @@ def main():
 
     time_start = time.perf_counter()
 
+
+    # Section: Results
+    def write_results_and_exit(results):
+        import json
+        import sys
+
+        results['timings']['total'] = time.perf_counter() - time_start
+
+        with open('results.json', 'w') as handle:
+            json.dump(results, handle)
+
+        sys.exit(0)
 
     # Section: Structure definition
     from pyscf import gto
@@ -40,19 +51,19 @@ def main():
     results['timings']['mean_field'] = time.perf_counter() - mean_field_start
     results['total_energy'] = mean_field_run.e_tot
     results['forces'] = (- mean_field_run.nuc_grad_method().kernel()).tolist()
-    results['molecular_orbitals'] = {}
-    results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
-    results['molecular_orbitals']['labels'] = structure.ao_labels()
-    results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+
+    if mean_field_run.converged:
+        results['molecular_orbitals'] = {}
+        results['molecular_orbitals']['energies'] = mean_field_run.mo_energy.tolist()
+        results['molecular_orbitals']['labels'] = structure.ao_labels()
+        results['molecular_orbitals']['occupations'] = mean_field_run.mo_occ.tolist()
+    else:
+        write_results_and_exit(results)
 
 
 
 
-    # Section: Results
-    results['timings']['total'] = time.perf_counter() - time_start
-
-    with open('results.json', 'w') as handle:
-        json.dump(results, handle)
+    write_results_and_exit(results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The script generated by the plugin would not check whether the SCF cycle actually converged, which could raise an exception in the lines that add properties to the `results` dictionary since the requested attributes may not be available. As a result, the `results.json` file would not be written and the parser would report `ERROR_OUTPUT_RESULTS_MISSING` instead of `ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED`.

The solution is to add a conditional in the input script that checks whether the SCF cycle actually converged and only then try and access the output variables. This should guarantee that the `results.json` file is written and retrieved such that the parser can successfully detect that the SCF cycle did not converge.