### PR TITLE
Bugfix/fcidump naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ The `active_spaces` and `occupations` keys are requires and each take a list of 
 For each element in the list, a FCIDUMP file is generated for the corresponding active spaces and the occupations of the orbitals.
 The shape of the `active_spaces` and `occupations` array has to be identical.
 
-The generated FCIDUMP files are attached as `SinglefileData` output nodes in the `fcidump` namespace, where the label is determined by the corresponding active space:
+The generated FCIDUMP files are attached as `SinglefileData` output nodes in the `fcidump` namespace, where the label is determined by the index of the corresponding active space in the list:
 ```python
-print(results['fcidump']['active_space_5_6_7_8'].get_content())
+print(results['fcidump']['active_space_0'].get_content())
  &FCI NORB=   4,NELEC= 4,MS2=0,
   ORBSYM=1,1,1,1,
   ISYM=1,

--- a/src/aiida_pyscf/calculations/templates/fcidump.py.j2
+++ b/src/aiida_pyscf/calculations/templates/fcidump.py.j2
@@ -2,16 +2,18 @@
 from pyscf.mcscf.casci import CASCI
 from pyscf.tools import fcidump
 
+cnt = 0
 for active_spaces, occupations in zip({{ fcidump.active_spaces }}, {{ fcidump.occupations }}):
     casci = CASCI(mean_field_run, len(active_spaces), sum(occupations))
     new_mo = casci.sort_mo(active_spaces)
     one_integral, shift = casci.h1e_for_cas(new_mo)
     two_integral = casci.get_h2eff(new_mo)
     fcidump.from_integrals(
-        f"active_space_{'_'.join([str(index) for index in active_spaces])}.fcidump",
+        f"active_space_{cnt}.fcidump",
         one_integral,
         two_integral,
         casci.ncas,
         casci.nelecas,
         nuc=shift
     )
+    cnt += 1

--- a/src/aiida_pyscf/calculations/templates/fcidump.py.j2
+++ b/src/aiida_pyscf/calculations/templates/fcidump.py.j2
@@ -2,18 +2,16 @@
 from pyscf.mcscf.casci import CASCI
 from pyscf.tools import fcidump
 
-cnt = 0
-for active_spaces, occupations in zip({{ fcidump.active_spaces }}, {{ fcidump.occupations }}):
+for index, (active_spaces, occupations) in enumerate(zip({{ fcidump.active_spaces }}, {{ fcidump.occupations }})):
     casci = CASCI(mean_field_run, len(active_spaces), sum(occupations))
     new_mo = casci.sort_mo(active_spaces)
     one_integral, shift = casci.h1e_for_cas(new_mo)
     two_integral = casci.get_h2eff(new_mo)
     fcidump.from_integrals(
-        f"active_space_{cnt}.fcidump",
+        f"active_space_{index}.fcidump",
         one_integral,
         two_integral,
         casci.ncas,
         casci.nelecas,
         nuc=shift
     )
-    cnt += 1

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -63,19 +63,21 @@ def main():
     from pyscf.mcscf.casci import CASCI
     from pyscf.tools import fcidump
 
+    cnt = 0
     for active_spaces, occupations in zip([[5, 6], [5, 7]], [[1, 1], [1, 1]]):
         casci = CASCI(mean_field_run, len(active_spaces), sum(occupations))
         new_mo = casci.sort_mo(active_spaces)
         one_integral, shift = casci.h1e_for_cas(new_mo)
         two_integral = casci.get_h2eff(new_mo)
         fcidump.from_integrals(
-            f"active_space_{'_'.join([str(index) for index in active_spaces])}.fcidump",
+            f"active_space_{cnt}.fcidump",
             one_integral,
             two_integral,
             casci.ncas,
             casci.nelecas,
             nuc=shift
         )
+        cnt += 1
 
     write_results_and_exit(results)
 

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -63,21 +63,19 @@ def main():
     from pyscf.mcscf.casci import CASCI
     from pyscf.tools import fcidump
 
-    cnt = 0
-    for active_spaces, occupations in zip([[5, 6], [5, 7]], [[1, 1], [1, 1]]):
+    for index, (active_spaces, occupations) in enumerate(zip([[5, 6], [5, 7]], [[1, 1], [1, 1]])):
         casci = CASCI(mean_field_run, len(active_spaces), sum(occupations))
         new_mo = casci.sort_mo(active_spaces)
         one_integral, shift = casci.h1e_for_cas(new_mo)
         two_integral = casci.get_h2eff(new_mo)
         fcidump.from_integrals(
-            f"active_space_{cnt}.fcidump",
+            f"active_space_{index}.fcidump",
             one_integral,
             two_integral,
             casci.ncas,
             casci.nelecas,
             nuc=shift
         )
-        cnt += 1
 
     write_results_and_exit(results)
 


### PR DESCRIPTION
I run into a number of issues regarding the naming of the fcidump files in the Aiida Pyscf plugin. First, if the number of orbitals in the active space is greater than about 35, then the file name becomes too long and the job fails. Second, when you have large number of orbitals and you are computing a large number of fcidump files, it becomes much more difficult to find a correspondence to the active spaces given in the input. The only way for the user to do this is to define the same function that is used to create the name in the first place, which is adding a burdensome step. Specifically, I notice this with the Autocas plugin. 

In my opinion, it is better to use the list index for maintaining the correspondence between the active spaces and the fcidump files. This solves the problems listed above. 