### PR TITLE
Bugfix/model pickle opt

### DIFF
--- a/src/aiida_pyscf/calculations/templates/results.py.j2
+++ b/src/aiida_pyscf/calculations/templates/results.py.j2
@@ -12,6 +12,8 @@ def write_results_and_exit(results):
     with open('{{ results.filename_model }}', 'wb') as handle:
         # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
         mean_field_run._chkfile = None
+        # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+        mean_field_run.opt = None
         dill.dump(mean_field_run, handle)
 
     sys.exit(0)

--- a/src/aiida_pyscf/calculations/templates/results.py.j2
+++ b/src/aiida_pyscf/calculations/templates/results.py.j2
@@ -12,7 +12,7 @@ def write_results_and_exit(results):
     with open('{{ results.filename_model }}', 'wb') as handle:
         # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
         mean_field_run._chkfile = None
-        # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+        # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
         mean_field_run.opt = None
         dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_checkpoint.pyr
+++ b/tests/calculations/test_base/test_checkpoint.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_checkpoint.pyr
+++ b/tests/calculations/test_base/test_checkpoint.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_default.pyr
+++ b/tests/calculations/test_base/test_default.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters0_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters0_.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters0_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters0_.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters1_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters1_.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters1_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters1_.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters2_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters2_.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters2_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters2_.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters3_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters3_.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_cubegen_parameters3_.pyr
+++ b/tests/calculations/test_base/test_parameters_cubegen_parameters3_.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_fcidump.pyr
+++ b/tests/calculations/test_base/test_parameters_fcidump.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_hessian.pyr
+++ b/tests/calculations/test_base/test_parameters_hessian.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_hessian.pyr
+++ b/tests/calculations/test_base/test_parameters_hessian.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_mean_field.pyr
+++ b/tests/calculations/test_base/test_parameters_mean_field.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_mean_field.pyr
+++ b/tests/calculations/test_base/test_parameters_mean_field.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_optimizer.pyr
+++ b/tests/calculations/test_base/test_parameters_optimizer.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 

--- a/tests/calculations/test_base/test_parameters_structure.pyr
+++ b/tests/calculations/test_base/test_parameters_structure.pyr
@@ -26,6 +26,8 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
+            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 
         sys.exit(0)

--- a/tests/calculations/test_base/test_parameters_structure.pyr
+++ b/tests/calculations/test_base/test_parameters_structure.pyr
@@ -26,7 +26,7 @@ def main():
         with open('model.pickle', 'wb') as handle:
             # Need to unset the ``_chkfile`` attribute as it contains an open file handle which cannot be unpickled.
             mean_field_run._chkfile = None
-            # Need to unset the ``opt`` attribute as it is ctypes objects containing pointers cannot be pickled.
+            # Need to unset the ``opt`` attribute as it contains ctypes objects containing pointers which cannot be pickled.
             mean_field_run.opt = None
             dill.dump(mean_field_run, handle)
 


### PR DESCRIPTION
`.opt` attribute of `model` cannot be pickled.
remove the `.opt` attribute like `.chkfile` to avoid except.