### PR TITLE
Dependencies: Put upper limit `pyscf<2.4`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     'dill',
     'numpy',
     'pint',
-    'pyscf[geomopt]~=2.2',
+    'pyscf[geomopt]~=2.2,<2.4',
 ]
 
 [project.urls]


### PR DESCRIPTION
The release `pyscf==2.4` released on October 16 2023 breaks the unpickling of models.