### PR TITLE
`PyscfCalculation`: Make `cubegen` output namespace optional

### DIFF
--- a/src/aiida_pyscf/calculations/base.py
+++ b/src/aiida_pyscf/calculations/base.py
@@ -108,6 +108,7 @@ class PyscfCalculation(CalcJob):
             required=False,
             help='The molecular electrostatic potential (MEP) in `.cube` format.',
         )
+        spec.outputs['cubegen'].required = False
         spec.output(
             'hessian',
             valid_type=ArrayData,


### PR DESCRIPTION
The subspaces for the `cubegen` output namespace were already correctly marked optional. However, the namespace itself was still technically required. The `PyscfBaseWorkChain` would emit a warning because of this if the calculation did not report any outputs in the `cubegen` namespace:

    required output `cubegen` was not an output of PyscfCalculation<*>

The namespace is now explicitly marked as optional to correct this.